### PR TITLE
corrected README file extension on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-with open("README.md", "rb") as f:
+with open("README.rst", "rb") as f:
     long_descr = f.read().decode("utf-8")
 
 setup(


### PR DESCRIPTION
previous version was preventing installation when using pip install -e .