### PR TITLE
Implementing Enhancement to add Seeds and Peers to the result table

### DIFF
--- a/ezflix/extractors/eztv.py
+++ b/ezflix/extractors/eztv.py
@@ -24,13 +24,14 @@ def eztv(q, limit, quality=None):
             break
 
         if q.lower().strip()[0] in magnet['title'].lower():
-            seeds = magnet.find_parent().find_parent().find("font").get_text()
+            seeds = magnet.find_parent().find_parent().find("font").get_text() # verified for the edge cases
+            peers = "-" # as eztv doesn't give any peers detail, atleast not on the search page.
             if quality is not None:
                 if quality in magnet['title']:
-                    arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds})
+                    arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds, 'peers': peers})
                     count += 1
             else:
-                arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds})
+                arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds, 'peers': peers})
                 count += 1
 
     return arr

--- a/ezflix/extractors/eztv.py
+++ b/ezflix/extractors/eztv.py
@@ -24,12 +24,13 @@ def eztv(q, limit, quality=None):
             break
 
         if q.lower().strip()[0] in magnet['title'].lower():
+            seeds = magnet.find_parent().find_parent().find("font").get_text()
             if quality is not None:
                 if quality in magnet['title']:
-                    arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href']})
+                    arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds})
                     count += 1
             else:
-                arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href']})
+                arr.append({'id': count, 'title': magnet['title'][:-12], 'magnet': magnet['href'], 'seeds': seeds})
                 count += 1
 
     return arr

--- a/ezflix/extractors/yts.py
+++ b/ezflix/extractors/yts.py
@@ -27,9 +27,9 @@ def yts(query_term, quality=None, limit=20, minimum_rating=4, sort_by='seeds', s
             title = '%s (%s) (%s)' % (r['title'], r['year'], torrent['quality'])
             if quality is not None:
                 if quality == torrent['quality']:
-                    arr.append({'id': count, 'title': title, 'magnet': torrent['url']})
+                    arr.append({'id': count, 'title': title, 'magnet': torrent['url'], 'seeds': torrent['seeds'], 'peers': torrent['peers']})
                     count += 1
             else:
-                arr.append({'id': count, 'title': title, 'magnet': torrent['url']})
+                arr.append({'id': count, 'title': title, 'magnet': torrent['url'], 'seeds': torrent['seeds'], 'peers': torrent['peers']})
                 count += 1
     return arr

--- a/ezflix/main.py
+++ b/ezflix/main.py
@@ -44,10 +44,10 @@ def main():
         peerflix(latest['magnet'], media_player, args.media_type, args.subtitles, args.remove, file_path)
         sys.exit()
     row = PrettyTable()
-    row.field_names = ["Id", "Torrent"]
+    row.field_names = ["Id", "Torrent", "Seeds"]
     row.align = 'l'
     for result in torrents:
-        row.add_row([result['id'], result['title']])
+        row.add_row([result['id'], result['title'], result['seeds']])
     print(row)
     print(colorful.bold("Make selection: (Enter quit to close the program)"))
     while True:

--- a/ezflix/main.py
+++ b/ezflix/main.py
@@ -44,10 +44,10 @@ def main():
         peerflix(latest['magnet'], media_player, args.media_type, args.subtitles, args.remove, file_path)
         sys.exit()
     row = PrettyTable()
-    row.field_names = ["Id", "Torrent", "Seeds"]
+    row.field_names = ["Id", "Torrent", "Seeds", "Peers"]
     row.align = 'l'
     for result in torrents:
-        row.add_row([result['id'], result['title'], result['seeds']])
+        row.add_row([result['id'], result['title'], result['seeds'], result['peers']])
     print(row)
     print(colorful.bold("Make selection: (Enter quit to close the program)"))
     while True:


### PR DESCRIPTION
Implementing #10 
---
It was pretty straightforward to parse seeds and peers in **YTS api** as they were already in this torrent dictionary here:
https://github.com/AnthonyBloomer/ezflix/blob/ce4e99ad222f91e6bc3370bde7419e73859b2fc9/ezflix/extractors/yts.py#L26

So, it was matter of adding the respecting keys `torrent['seeds']` and `torrent['peers']` and appending them in arr list.

---

For, **YTS** scrapping though, I noticed, it only gives number of Seeds in the search result table, and the only unique identifier was <font> tag in <div.forum_thread_post>, so I referenced to it via:

`seeds = find_parent().find_parent().find("font").get_text()`

after line:

https://github.com/AnthonyBloomer/ezflix/blob/ce4e99ad222f91e6bc3370bde7419e73859b2fc9/ezflix/extractors/eztv.py#L21

and then just appending seeds to the arr list. Since there were no peers, I appended Peers: "-" for easy to modify in future and maintain parity in the final result table.

---

After this, I just had to add "Seeds" and "Peers" column on line:
https://github.com/AnthonyBloomer/ezflix/blob/ce4e99ad222f91e6bc3370bde7419e73859b2fc9/ezflix/main.py#L47

and query them on result dict with `result['seeds']` and `result['peers']`.

---

This is my first pull request to any project, so please help me understand if I am not following any convention here. Thanks! 🤓 